### PR TITLE
Fix/optimize structure

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "singleQuote": true,
+  "tabWidth": 4,
+  "trailingComma": "es5",
+  "semi": false
+}

--- a/src/App.js
+++ b/src/App.js
@@ -10,31 +10,44 @@ import StageF from './views/StageF/StageF'
 import { Provider } from './context/stageContext'
 import './styles/global.scss'
 
+const generateStageSection = (stageSection) => {
+  switch (stageSection) {
+    case "A":
+      return <StageA />
+    case "B":
+      return <StageB />
+    case "C":
+      return <StageC />
+    case "D":
+      return <StageD />
+    case "E":
+      return <StageE />
+    case "F":
+      return <StageF />
+    // default 之後要改成 return <StageA />;
+    default:
+      return <Sample />
+  }
+};
 
 function App() {
   const [layoutColor, setLayoutColor] = useState('A1')
   const [userName, setUserName] = useState('林怡珊')
   const [stage, setStage] = useState('sample')
+  const stageSection = stage.charAt(0)
+
   return (
     <div className="App">
-      <Provider value={{
-        layoutColor,
-        setLayoutColor,
-        userName,
-        setUserName,
-        stage,
-        setStage
-      }}>
-        <Layout>
-          {stage === 'sample' && <Sample />}
-          {stage === 'A' && <StageA />}
-          {stage === 'B' && <StageB />}
-          {stage === 'C' && <StageC />}
-          {stage === 'D' && <StageD />}
-          {stage === 'E' && <StageE />}
-        </Layout>
+      <Provider
+        value={{
+          userName,
+          setUserName,
+          stage,
+          setStage,
+        }}
+      >
+        <Layout>{generateStageSection(stageSection)}</Layout>
       </Provider>
-
     </div>
   );
 }

--- a/src/App.js
+++ b/src/App.js
@@ -31,7 +31,6 @@ const generateStageSection = (stageSection) => {
 };
 
 function App() {
-  const [layoutColor, setLayoutColor] = useState('A1')
   const [userName, setUserName] = useState('林怡珊')
   const [stage, setStage] = useState('sample')
   const stageSection = stage.charAt(0)

--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import StageB from './views/StageB/StageB'
 import StageC from './views/StageC/StageC'
 import StageD from './views/StageD/StageD'
 import StageE from './views/StageE/StageE'
+import StageF from './views/StageF/StageF'
 import { Provider } from './context/stageContext'
 import './styles/global.scss'
 

--- a/src/components/Layout/Layout.js
+++ b/src/components/Layout/Layout.js
@@ -4,20 +4,39 @@ import stageContext from './../../context/stageContext'
 import { colors } from './../../styles/global.js'
 
 const colorObject = {
+  // sample 的部分之後可以刪掉
+  sample: colors.Grayscale600,
+  sampleNext: colors.Grayscale600,
+
   A1: colors.Grayscale600,
+  A2: colors.Grayscale600,
   B1: colors.Yellow200,
+  B2: colors.Yellow200,
+  B3: colors.Yellow200,
   B4: colors.Yellow100,
+  B5: colors.Yellow100,
   C1: colors.Blue300,
+  C2: colors.Blue300,
+  C3: colors.Blue300,
+  C4: colors.Blue300,
+  C5: colors.Blue300,
+  C6: colors.Blue300,
   C7: colors.Blue100,
   D1: colors.Blue300,
+  D2: colors.Blue300,
+  D3: colors.Blue300,
+  D4: colors.Blue300,
+  D5: colors.Blue300,
+  D6: colors.Blue300,
   D7: colors.Red100,
   E1: colors.Lightblue300,
+  E2: colors.Lightblue300,
   E3: colors.Lightblue100,
-}
+};
 const Layout = ({ children }) => {
-  const { layoutColor } = useContext(stageContext)
+  const { stage } = useContext(stageContext);
   return (
-    <div className='Layout' style={{ background: colorObject[layoutColor] }}>
+    <div className="Layout" style={{ background: colorObject[stage] }}>
       {children}
     </div>
   )

--- a/src/views/Sample/Sample.js
+++ b/src/views/Sample/Sample.js
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react'
+import React, { useContext } from 'react'
 import stageContext from '../../context/stageContext'
 import WhiteBlock from '../../components/WhiteBlock/WhiteBlock'
 import Bug from '../../components/Bug/Bug.js'
@@ -7,16 +7,25 @@ import './Sample.scss'
 
 const Sample = () => {
   const { userName } = useContext(stageContext)
-  const [next, setNext] = useState(true)
+  const { stage, setStage } = useContext(stageContext)
+  const next = stage === "sampleNext"
   return (
     <div className="Sample">
       <Bug color={'#aaa'} position={'leftBottom'} />
       <Bug smile={next} position={'leftTop'} />
       <Bug look={next} color={'#faf'} position={'rightTop'} />
       <Bug look={next} eyeColor={'#aaf'} position={'rightBottom'} />
-      <WhiteBlock button={<Button arrow color={'lightblue'} onClick={() => setNext(!next)} />}>
-        <div className='textContainer'>
-          {next ?
+      <WhiteBlock
+        button={
+          <Button
+            arrow
+            color={"lightblue"}
+            onClick={() => setStage("sampleNext")}
+          />
+        }
+      >
+        <div className="textContainer">
+          {next ? (
             <>
               <p>嗨！{userName} 歡迎加入 TT 資訊</p>
               <p>在正式加入專案開發之前</p>
@@ -24,13 +33,12 @@ const Sample = () => {
               <p className='marginTop'>請接受挑戰任務</p>
               <p>成功通過 Scrum 新手村的挑戰吧！</p>
             </>
-            :
+          ) : (
             <>
               <p>什麼叫這不是你想要的！？</p>
               <p>那你來報到幹嘛...</p>
             </>
-          }
-
+          )}
         </div>
       </WhiteBlock>
     </div>

--- a/src/views/StageF/StageF.js
+++ b/src/views/StageF/StageF.js
@@ -1,0 +1,8 @@
+import React from "react";
+import "./StageF.scss";
+
+const StageF = () => {
+  return <div className="StageF"></div>;
+};
+
+export default StageF;

--- a/src/views/StageF/StageF.scss
+++ b/src/views/StageF/StageF.scss
@@ -1,0 +1,8 @@
+@import "./../../styles/mixin.scss";
+
+.StageF {
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+  position: relative;
+}


### PR DESCRIPTION
- 新增 prettier 的設定檔 (@a5757657 可以按照你的習慣做設定)，不然大家的分號、單雙引號會不統一。
- 有補上 StageF 的元件
- 將 狀態 做優化
  - 將狀態 stage 改為 每頁的代號 (ex. A1)
  - App 元件中判斷 section 的方式，就改為 取 stage 的第一個字元做判斷。
  - 每頁的元件可以直接透過 `useContext` 做 `setStage`，不用再新增一個 local state。
  - 把 狀態 layoutColor 拔掉，直接使用 stage 即可達成更換背景色的邏輯判斷。